### PR TITLE
remove touchevents

### DIFF
--- a/src/hooks/useHandleCanvasMouseDown.ts
+++ b/src/hooks/useHandleCanvasMouseDown.ts
@@ -380,7 +380,7 @@ export const useHandleCanvasMouseDown = ({
 	);
 
 	const handleMouseDown = useCallback(
-		(event: React.TouchEvent | React.MouseEvent) => {
+		(event: React.MouseEvent) => {
 			const enterBindMode = () => {
 				dispatch(setMode(Mode.Bind));
 				dispatch(setAction(true));

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -282,16 +282,12 @@ export const computeLimit = (equation: WallEquation, size: number, coords: Point
 };
 
 export const calculateSnap = (
-	event: React.TouchEvent | React.MouseEvent,
+	event: React.MouseEvent,
 	viewbox: ViewboxData
 ): SnapData => {
 	let eY = 0;
 	let eX = 0;
-	if (event.nativeEvent instanceof TouchEvent && event.nativeEvent.touches) {
-		const touches = event.nativeEvent.changedTouches;
-		eX = touches[0].pageX;
-		eY = touches[0].pageY;
-	} else if (event.nativeEvent instanceof MouseEvent) {
+	if (event.nativeEvent instanceof MouseEvent) {
 		eX = event.nativeEvent.pageX;
 		eY = event.nativeEvent.pageY;
 	} else {


### PR DESCRIPTION
Current use of touchevents is breaking functionality in both Firefox and Safari. 